### PR TITLE
In matplotlib plotting tutorial: change from plt.Figure to plt.figure

### DIFF
--- a/matplotlib_plotting/using_matplotlib_to_make_figures_complete.ipynb
+++ b/matplotlib_plotting/using_matplotlib_to_make_figures_complete.ipynb
@@ -456,7 +456,7 @@
    },
    "outputs": [],
    "source": [
-    "fig = plt.Figure(figsize=(7.8, 5))"
+    "fig = plt.figure(figsize=(7.8, 5))"
    ]
   },
   {


### PR DESCRIPTION
With this, the plotting window is shown while making the plot